### PR TITLE
require zend-servicemanager 2.4 instead of 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["zf2", "module", "zendesk", "api"],
     "require": {
         "php": "~5.4",
-        "zendframework/zend-servicemanager": "^2.6",
+        "zendframework/zend-servicemanager": "^2.4",
         "zendesk/zendesk_api_client_php": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Service Manager 2.6 requires Zend Framework 2.5.

This PR use service-manager 2.5, which allows developers to use zf 2.4 .

See #1 